### PR TITLE
[DD-1165] remove ssl hack

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,12 +36,6 @@ FROM build AS publish
 RUN dotnet publish "./Doppler.UsersApi/Doppler.UsersApi.csproj" -c Release -o /app/publish
 
 FROM mcr.microsoft.com/dotnet/aspnet:6.0.6-bullseye-slim AS final
-# We need these changes in openssl.cnf to access to our SQL Server instances in QA and INT environments
-# See more information in https://stackoverflow.com/questions/56473656/cant-connect-to-sql-server-named-instance-from-asp-net-core-running-in-docker/59391426#59391426
-RUN sed -i 's/DEFAULT@SECLEVEL=2/DEFAULT@SECLEVEL=1/g' /etc/ssl/openssl.cnf
-RUN sed -i 's/MinProtocol = TLSv1.2/MinProtocol = TLSv1/g' /etc/ssl/openssl.cnf
-RUN sed -i 's/DEFAULT@SECLEVEL=2/DEFAULT@SECLEVEL=1/g' /usr/lib/ssl/openssl.cnf
-RUN sed -i 's/MinProtocol = TLSv1.2/MinProtocol = TLSv1/g' /usr/lib/ssl/openssl.cnf
 WORKDIR /app
 EXPOSE 80
 COPY --from=publish /app/publish .


### PR DESCRIPTION
This hack was introduced to allow connect to testing database running in an old windows server that support TLS 1.1 as max version

Now we have the database running in a server with a most recent version that support TLS 1.2 and this hack is obsolete