### PR TITLE
[DOI-1456] Add user related accounts endpoint

### DIFF
--- a/Doppler.UsersApi.Test/GetRelatedUsersByTypeTest.cs
+++ b/Doppler.UsersApi.Test/GetRelatedUsersByTypeTest.cs
@@ -10,15 +10,13 @@ using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
-using Doppler.UsersApi.Encryption;
-using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 using Xunit.Abstractions;
 using System;
 
 namespace Doppler.UsersApi.Test
 {
-    public class GetRelatedUsersByTypeTest : IClassFixture<WebApplicationFactory<Startup>>
+    public class GetUserInvitationsTest : IClassFixture<WebApplicationFactory<Startup>>
     {
         const string TOKEN_ACCOUNT_123_TEST1_AT_TEST_DOT_COM_EXPIRE_20330518 = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1laWQiOjEyMywidW5pcXVlX25hbWUiOiJ0ZXN0MUB0ZXN0LmNvbSIsInJvbGUiOiJVU0VSIiwiZXhwIjoyMDAwMDAwMDAwfQ.E3RHjKx9p0a-64RN2YPtlEMysGM45QBO9eATLBhtP4tUQNZnkraUr56hAWA-FuGmhiuMptnKNk_dU3VnbyL6SbHrMWUbquxWjyoqsd7stFs1K_nW6XIzsTjh8Bg6hB5hmsSV-M5_hPS24JwJaCdMQeWrh6cIEp2Sjft7I1V4HQrgzrkMh15sDFAw3i1_ZZasQsDYKyYbO9Jp7lx42ognPrz_KuvPzLjEXvBBNTFsVXUE-ur5adLNMvt-uXzcJ1rcwhjHWItUf5YvgRQbbBnd9f-LsJIhfkDgCJcvZmGDZrtlCKaU1UjHv5c3faZED-cjL59MbibofhPjv87MK8hhdg";
         const string TOKEN_ACCOUNT_123_TEST1_AT_TEST_DOT_COM_EXPIRE_20010908 = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1laWQiOjEyMywidW5pcXVlX25hbWUiOiJ0ZXN0MUB0ZXN0LmNvbSIsInJvbGUiOiJVU0VSIiwiZXhwIjoxMDAwMDAwMDAwfQ.JBmiZBgKVSUtB4_NhD1kiUhBTnH2ufGSzcoCwC3-Gtx0QDvkFjy2KbxIU9asscenSdzziTOZN6IfFx6KgZ3_a3YB7vdCgfSINQwrAK0_6Owa-BQuNAIsKk-pNoIhJ-OcckV-zrp5wWai3Ak5Qzg3aZ1NKZQKZt5ICZmsFZcWu_4pzS-xsGPcj5gSr3Iybt61iBnetrkrEbjtVZg-3xzKr0nmMMqe-qqeknozIFy2YWAObmTkrN4sZ3AB_jzqyFPXN-nMw3a0NxIdJyetbESAOcNnPLymBKZEZmX2psKuXwJxxekvgK9egkfv2EjKYF9atpH5XwC0Pd4EWvraLAL2eg";
@@ -26,19 +24,19 @@ namespace Doppler.UsersApi.Test
         private readonly WebApplicationFactory<Startup> _factory;
         private readonly ITestOutputHelper _output;
 
-        public GetRelatedUsersByTypeTest(WebApplicationFactory<Startup> factory, ITestOutputHelper output)
+        public GetUserInvitationsTest(WebApplicationFactory<Startup> factory, ITestOutputHelper output)
         {
             _factory = factory;
             _output = output;
         }
 
         [Fact]
-        public async Task GET_related_users_by_type_should_return_not_found_when_empty_db_result()
+        public async Task GET_user_invitations_should_return_not_found_when_empty_db_result()
         {
             // Arrange
             var mockConnection = new Mock<DbConnection>();
 
-            mockConnection.SetupDapperAsync(c => c.QueryAsync<BasicUserInformation>(null, null, null, null, null)).ReturnsAsync(Enumerable.Empty<BasicUserInformation>());
+            mockConnection.SetupDapperAsync(c => c.QueryAsync<InvitationInformation>(null, null, null, null, null)).ReturnsAsync(Enumerable.Empty<InvitationInformation>());
 
             var client = _factory.WithWebHostBuilder(builder =>
             {
@@ -49,7 +47,7 @@ namespace Doppler.UsersApi.Test
 
             }).CreateClient(new WebApplicationFactoryClientOptions());
 
-            var request = new HttpRequestMessage(HttpMethod.Get, "accounts/test1@test.com/related-users/1")
+            var request = new HttpRequestMessage(HttpMethod.Get, "accounts/test1@test.com/user-invitations")
             {
                 Headers = { { "Authorization", $"Bearer {TOKEN_ACCOUNT_123_TEST1_AT_TEST_DOT_COM_EXPIRE_20330518}" } }
             };
@@ -66,12 +64,12 @@ namespace Doppler.UsersApi.Test
         [InlineData(TOKEN_ACCOUNT_123_TEST1_AT_TEST_DOT_COM_EXPIRE_20010908)]
         [InlineData("")]
         [InlineData("invalid")]
-        public async Task GET_related_users_by_type_should_return_unauthorized_when_token_is_invalid(string token)
+        public async Task GET_user_invitations_should_return_unauthorized_when_token_is_invalid(string token)
         {
             // Arrange
             var client = _factory.CreateClient(new WebApplicationFactoryClientOptions());
 
-            var request = new HttpRequestMessage(HttpMethod.Get, "accounts/test1@test.com/related-users/1")
+            var request = new HttpRequestMessage(HttpMethod.Get, "accounts/test1@test.com/user-invitations")
             {
                 Headers = { { "Authorization", $"Bearer {token}" } }
             };
@@ -84,12 +82,12 @@ namespace Doppler.UsersApi.Test
         }
 
         [Fact]
-        public async Task GET_related_users_by_type_should_return_unauthorized_when_authorization_is_empty()
+        public async Task GET_user_invitations_should_return_unauthorized_when_authorization_is_empty()
         {
             // Arrange
             var client = _factory.CreateClient(new WebApplicationFactoryClientOptions());
 
-            var request = new HttpRequestMessage(HttpMethod.Get, "accounts/test1@test.com/related-users/1");
+            var request = new HttpRequestMessage(HttpMethod.Get, "accounts/test1@test.com/user-invitations");
 
             // Act
             var response = await client.SendAsync(request);
@@ -99,12 +97,12 @@ namespace Doppler.UsersApi.Test
         }
 
         [Fact]
-        public async Task GET_related_users_by_type_should_return_right_value_based_on_db_response()
+        public async Task GET_user_invitations_should_return_right_value_based_on_db_response()
         {
             // Arrange
             var currentDate = DateTime.UtcNow;
 
-            var dbResponse = new BasicUserInformation
+            var dbResponse = new InvitationInformation
             {
                 Email = "test1@test.com",
                 Firstname = "Test First Name",
@@ -117,7 +115,7 @@ namespace Doppler.UsersApi.Test
 
             var mockConnection = new Mock<DbConnection>();
 
-            mockConnection.SetupDapperAsync(c => c.QueryFirstOrDefaultAsync<BasicUserInformation>(null, null, null, null, null))
+            mockConnection.SetupDapperAsync(c => c.QueryFirstOrDefaultAsync<InvitationInformation>(null, null, null, null, null))
                 .ReturnsAsync(dbResponse);
 
             var client = _factory.WithWebHostBuilder(builder =>
@@ -129,7 +127,7 @@ namespace Doppler.UsersApi.Test
 
             }).CreateClient(new WebApplicationFactoryClientOptions());
 
-            var request = new HttpRequestMessage(HttpMethod.Get, "accounts/test1@test.com/related-users/1")
+            var request = new HttpRequestMessage(HttpMethod.Get, "accounts/test1@test.com/user-invitations")
             {
                 Headers = { { "Authorization", $"Bearer {TOKEN_ACCOUNT_123_TEST1_AT_TEST_DOT_COM_EXPIRE_20330518}" } }
             };

--- a/Doppler.UsersApi.Test/GetRelatedUsersByTypeTest.cs
+++ b/Doppler.UsersApi.Test/GetRelatedUsersByTypeTest.cs
@@ -1,0 +1,146 @@
+using Dapper;
+using Doppler.UsersApi.Model;
+using Doppler.UsersApi.Test.Utils;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.TestHost;
+using Moq;
+using Moq.Dapper;
+using System.Data.Common;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Doppler.UsersApi.Encryption;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+using Xunit.Abstractions;
+using System;
+
+namespace Doppler.UsersApi.Test
+{
+    public class GetRelatedUsersByTypeTest : IClassFixture<WebApplicationFactory<Startup>>
+    {
+        const string TOKEN_ACCOUNT_123_TEST1_AT_TEST_DOT_COM_EXPIRE_20330518 = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1laWQiOjEyMywidW5pcXVlX25hbWUiOiJ0ZXN0MUB0ZXN0LmNvbSIsInJvbGUiOiJVU0VSIiwiZXhwIjoyMDAwMDAwMDAwfQ.E3RHjKx9p0a-64RN2YPtlEMysGM45QBO9eATLBhtP4tUQNZnkraUr56hAWA-FuGmhiuMptnKNk_dU3VnbyL6SbHrMWUbquxWjyoqsd7stFs1K_nW6XIzsTjh8Bg6hB5hmsSV-M5_hPS24JwJaCdMQeWrh6cIEp2Sjft7I1V4HQrgzrkMh15sDFAw3i1_ZZasQsDYKyYbO9Jp7lx42ognPrz_KuvPzLjEXvBBNTFsVXUE-ur5adLNMvt-uXzcJ1rcwhjHWItUf5YvgRQbbBnd9f-LsJIhfkDgCJcvZmGDZrtlCKaU1UjHv5c3faZED-cjL59MbibofhPjv87MK8hhdg";
+        const string TOKEN_ACCOUNT_123_TEST1_AT_TEST_DOT_COM_EXPIRE_20010908 = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1laWQiOjEyMywidW5pcXVlX25hbWUiOiJ0ZXN0MUB0ZXN0LmNvbSIsInJvbGUiOiJVU0VSIiwiZXhwIjoxMDAwMDAwMDAwfQ.JBmiZBgKVSUtB4_NhD1kiUhBTnH2ufGSzcoCwC3-Gtx0QDvkFjy2KbxIU9asscenSdzziTOZN6IfFx6KgZ3_a3YB7vdCgfSINQwrAK0_6Owa-BQuNAIsKk-pNoIhJ-OcckV-zrp5wWai3Ak5Qzg3aZ1NKZQKZt5ICZmsFZcWu_4pzS-xsGPcj5gSr3Iybt61iBnetrkrEbjtVZg-3xzKr0nmMMqe-qqeknozIFy2YWAObmTkrN4sZ3AB_jzqyFPXN-nMw3a0NxIdJyetbESAOcNnPLymBKZEZmX2psKuXwJxxekvgK9egkfv2EjKYF9atpH5XwC0Pd4EWvraLAL2eg";
+
+        private readonly WebApplicationFactory<Startup> _factory;
+        private readonly ITestOutputHelper _output;
+
+        public GetRelatedUsersByTypeTest(WebApplicationFactory<Startup> factory, ITestOutputHelper output)
+        {
+            _factory = factory;
+            _output = output;
+        }
+
+        [Fact]
+        public async Task GET_related_users_by_type_should_return_not_found_when_empty_db_result()
+        {
+            // Arrange
+            var mockConnection = new Mock<DbConnection>();
+
+            mockConnection.SetupDapperAsync(c => c.QueryAsync<BasicUserInformation>(null, null, null, null, null)).ReturnsAsync(Enumerable.Empty<BasicUserInformation>());
+
+            var client = _factory.WithWebHostBuilder(builder =>
+            {
+                builder.ConfigureTestServices(services =>
+                {
+                    services.SetupConnectionFactory(mockConnection.Object);
+                });
+
+            }).CreateClient(new WebApplicationFactoryClientOptions());
+
+            var request = new HttpRequestMessage(HttpMethod.Get, "accounts/test1@test.com/related-users/1")
+            {
+                Headers = { { "Authorization", $"Bearer {TOKEN_ACCOUNT_123_TEST1_AT_TEST_DOT_COM_EXPIRE_20330518}" } }
+            };
+
+            // Act
+            var response = await client.SendAsync(request);
+            _output.WriteLine(response.GetHeadersAsString());
+
+            // Assert
+            Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+        }
+
+        [Theory]
+        [InlineData(TOKEN_ACCOUNT_123_TEST1_AT_TEST_DOT_COM_EXPIRE_20010908)]
+        [InlineData("")]
+        [InlineData("invalid")]
+        public async Task GET_related_users_by_type_should_return_unauthorized_when_token_is_invalid(string token)
+        {
+            // Arrange
+            var client = _factory.CreateClient(new WebApplicationFactoryClientOptions());
+
+            var request = new HttpRequestMessage(HttpMethod.Get, "accounts/test1@test.com/related-users/1")
+            {
+                Headers = { { "Authorization", $"Bearer {token}" } }
+            };
+
+            // Act
+            var response = await client.SendAsync(request);
+
+            // Assert
+            Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+        }
+
+        [Fact]
+        public async Task GET_related_users_by_type_should_return_unauthorized_when_authorization_is_empty()
+        {
+            // Arrange
+            var client = _factory.CreateClient(new WebApplicationFactoryClientOptions());
+
+            var request = new HttpRequestMessage(HttpMethod.Get, "accounts/test1@test.com/related-users/1");
+
+            // Act
+            var response = await client.SendAsync(request);
+
+            // Assert
+            Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+        }
+
+        [Fact]
+        public async Task GET_related_users_by_type_should_return_right_value_based_on_db_response()
+        {
+            // Arrange
+            var currentDate = DateTime.UtcNow;
+
+            var dbResponse = new BasicUserInformation
+            {
+                Email = "test1@test.com",
+                Firstname = "Test First Name",
+                Lastname = "Test Last Name",
+                InvitationDate = currentDate,
+                InvitationStatus = 1
+            };
+
+            var expectedContent = string.Format("[{{\"email\":\"test1@test.com\",\"firstname\":\"Test First Name\",\"lastname\":\"Test Last Name\",\"invitationDate\":\"{0}\",\"invitationStatus\":1}}]", currentDate.ToString("yyyy-MM-ddTHH:mm:ss.fffffff"));
+
+            var mockConnection = new Mock<DbConnection>();
+
+            mockConnection.SetupDapperAsync(c => c.QueryFirstOrDefaultAsync<BasicUserInformation>(null, null, null, null, null))
+                .ReturnsAsync(dbResponse);
+
+            var client = _factory.WithWebHostBuilder(builder =>
+            {
+                builder.ConfigureTestServices(services =>
+                {
+                    services.SetupConnectionFactory(mockConnection.Object);
+                });
+
+            }).CreateClient(new WebApplicationFactoryClientOptions());
+
+            var request = new HttpRequestMessage(HttpMethod.Get, "accounts/test1@test.com/related-users/1")
+            {
+                Headers = { { "Authorization", $"Bearer {TOKEN_ACCOUNT_123_TEST1_AT_TEST_DOT_COM_EXPIRE_20330518}" } }
+            };
+
+            // Act
+            var response = await client.SendAsync(request);
+            var responseContent = await response.Content.ReadAsStringAsync();
+            _output.WriteLine(responseContent);
+
+            // Assert
+            Assert.Equal(expectedContent, responseContent);
+        }
+    }
+}

--- a/Doppler.UsersApi/Controllers/AccountController.cs
+++ b/Doppler.UsersApi/Controllers/AccountController.cs
@@ -57,10 +57,10 @@ namespace Doppler.UsersApi.Controllers
             return new OkObjectResult("Successfully");
         }
 
-        [HttpGet("/accounts/{accountName}/related-users/{userType}")]
-        public async Task<IActionResult> GetRelatedUsersByType(string accountName, int userType, CancellationToken cancellationToken = default)
+        [HttpGet("/accounts/{accountName}/user-invitations")]
+        public async Task<IActionResult> GetUserInvitations(string accountName, CancellationToken cancellationToken = default)
         {
-            var usersInformation = await _accountRepository.GetRelatedUsers(accountName, userType);
+            var usersInformation = await _accountRepository.GetUserInvitations(accountName);
 
             if (usersInformation.Any())
             {

--- a/Doppler.UsersApi/Controllers/AccountController.cs
+++ b/Doppler.UsersApi/Controllers/AccountController.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Doppler.UsersApi.Controllers
@@ -57,7 +58,7 @@ namespace Doppler.UsersApi.Controllers
         }
 
         [HttpGet("/accounts/{accountName}/related-users/{userType}")]
-        public async Task<IActionResult> GetRelatedUsersByType(string accountName, int userType)
+        public async Task<IActionResult> GetRelatedUsersByType(string accountName, int userType, CancellationToken cancellationToken = default)
         {
             var usersInformation = await _accountRepository.GetRelatedUsers(accountName, userType);
 

--- a/Doppler.UsersApi/Controllers/AccountController.cs
+++ b/Doppler.UsersApi/Controllers/AccountController.cs
@@ -4,6 +4,7 @@ using FluentValidation;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
+using System.Linq;
 using System.Threading.Tasks;
 
 namespace Doppler.UsersApi.Controllers
@@ -60,12 +61,12 @@ namespace Doppler.UsersApi.Controllers
         {
             var usersInformation = await _accountRepository.GetRelatedUsers(accountName, userType);
 
-            if (usersInformation == null)
+            if (usersInformation.Any())
             {
-                return new NotFoundResult();
+                return new OkObjectResult(usersInformation);
             }
 
-            return new OkObjectResult(usersInformation);
+            return new NotFoundResult();
         }
     }
 }

--- a/Doppler.UsersApi/Controllers/AccountController.cs
+++ b/Doppler.UsersApi/Controllers/AccountController.cs
@@ -54,5 +54,18 @@ namespace Doppler.UsersApi.Controllers
 
             return new OkObjectResult("Successfully");
         }
+
+        [HttpGet("/accounts/{accountName}/related-users/{userType}")]
+        public async Task<IActionResult> GetRelatedUsersByType(string accountName, int userType)
+        {
+            var usersInformation = await _accountRepository.GetRelatedUsers(accountName, userType);
+
+            if (usersInformation == null)
+            {
+                return new NotFoundResult();
+            }
+
+            return new OkObjectResult(usersInformation);
+        }
     }
 }

--- a/Doppler.UsersApi/Infrastructure/AccountRepository.cs
+++ b/Doppler.UsersApi/Infrastructure/AccountRepository.cs
@@ -91,25 +91,23 @@ WHERE
             using var connection = _connectionFactory.GetConnection();
             var result = await connection.QueryAsync<BasicUserInformation>(@"
 SELECT ua.Email,
-	ua.FirstName,
-	ua.LastName,
-	ci.UTCCreationDate AS InvitationDate,
-	ci.InviteStatus AS InvitationStatus
+    ua.FirstName,
+    ua.LastName,
+    ci.UTCCreationDate AS InvitationDate,
+    ci.InviteStatus AS InvitationStatus
 FROM [dbo].[User] u
-JOIN [dbo].[UserXUserAccount] uxua 
-	ON u.IdUser = uxua.IdUser
+JOIN [dbo].[UserXUserAccount] uxua
+    ON u.IdUser = uxua.IdUser
 JOIN [dbo].[UserAccount] ua
-	ON ua.IdUserAccount = uxua.IdUserAccount
-LEFT JOIN [dbo].[ColaborationInvites] ci 
-	ON ci.IdUserAccount = uxua.IdUserAccount
-		AND ci.IdUser = uxua.IdUser
+    ON ua.IdUserAccount = uxua.IdUserAccount
+LEFT JOIN [dbo].[ColaborationInvites] ci
+    ON ci.IdUserAccount = uxua.IdUserAccount
+        AND ci.IdUser = uxua.IdUser
 WHERE u.Email = @email
-	AND uxua.[Type] = @userType",
+    AND uxua.[Type] = @userType",
             new { email, userType });
 
-            var algo = result.ToList();
-
-            return algo;
+            return result.ToList();
         }
     }
 }

--- a/Doppler.UsersApi/Infrastructure/IAccountRepository.cs
+++ b/Doppler.UsersApi/Infrastructure/IAccountRepository.cs
@@ -1,6 +1,7 @@
 using Doppler.UsersApi.Model;
 using Microsoft.AspNetCore.Mvc;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Doppler.UsersApi.Infrastructure
@@ -9,6 +10,6 @@ namespace Doppler.UsersApi.Infrastructure
     {
         Task<ContactInformation> GetContactInformation(string accountName);
         Task UpdateContactInformation(string accountName, ContactInformation contactInformation);
-        Task<List<BasicUserInformation>> GetRelatedUsers(string email, int userType);
+        Task<List<BasicUserInformation>> GetRelatedUsers(string email, int userType, CancellationToken cancellationToken = default);
     }
 }

--- a/Doppler.UsersApi/Infrastructure/IAccountRepository.cs
+++ b/Doppler.UsersApi/Infrastructure/IAccountRepository.cs
@@ -10,6 +10,6 @@ namespace Doppler.UsersApi.Infrastructure
     {
         Task<ContactInformation> GetContactInformation(string accountName);
         Task UpdateContactInformation(string accountName, ContactInformation contactInformation);
-        Task<List<BasicUserInformation>> GetRelatedUsers(string email, int userType, CancellationToken cancellationToken = default);
+        Task<List<InvitationInformation>> GetUserInvitations(string email, CancellationToken cancellationToken = default);
     }
 }

--- a/Doppler.UsersApi/Infrastructure/IAccountRepository.cs
+++ b/Doppler.UsersApi/Infrastructure/IAccountRepository.cs
@@ -1,5 +1,6 @@
 using Doppler.UsersApi.Model;
 using Microsoft.AspNetCore.Mvc;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace Doppler.UsersApi.Infrastructure
@@ -8,5 +9,6 @@ namespace Doppler.UsersApi.Infrastructure
     {
         Task<ContactInformation> GetContactInformation(string accountName);
         Task UpdateContactInformation(string accountName, ContactInformation contactInformation);
+        Task<List<BasicUserInformation>> GetRelatedUsers(string email, int userType);
     }
 }

--- a/Doppler.UsersApi/Model/BasicUserInformation.cs
+++ b/Doppler.UsersApi/Model/BasicUserInformation.cs
@@ -3,12 +3,12 @@ using System;
 
 namespace Doppler.UsersApi.Model
 {
-    public class BasicUserInformation
+    public class InvitationInformation
     {
         public string Email { get; set; }
         public string Firstname { get; set; }
         public string Lastname { get; set; }
-        public DateTime? InvitationDate { get; set; }
-        public int? InvitationStatus { get; set; }
+        public DateTime InvitationDate { get; set; }
+        public int InvitationStatus { get; set; }
     }
 }

--- a/Doppler.UsersApi/Model/BasicUserInformation.cs
+++ b/Doppler.UsersApi/Model/BasicUserInformation.cs
@@ -1,3 +1,4 @@
+using Newtonsoft.Json;
 using System;
 
 namespace Doppler.UsersApi.Model
@@ -7,7 +8,7 @@ namespace Doppler.UsersApi.Model
         public string Email { get; set; }
         public string Firstname { get; set; }
         public string Lastname { get; set; }
-        public DateTime InvitationDate { get; set; }
-        public int InvitationStatus { get; set; }
+        public DateTime? InvitationDate { get; set; }
+        public int? InvitationStatus { get; set; }
     }
 }

--- a/Doppler.UsersApi/Model/BasicUserInformation.cs
+++ b/Doppler.UsersApi/Model/BasicUserInformation.cs
@@ -1,0 +1,13 @@
+using System;
+
+namespace Doppler.UsersApi.Model
+{
+    public class BasicUserInformation
+    {
+        public string Email { get; set; }
+        public string Firstname { get; set; }
+        public string Lastname { get; set; }
+        public DateTime InvitationDate { get; set; }
+        public int InvitationStatus { get; set; }
+    }
+}


### PR DESCRIPTION
This new endpoint will return UserAccounts related to a user. The only typeId we will be using for now is 3 (colaborator) but in the future we might have other user types.